### PR TITLE
Set skipInstall to false to avoid debug flag. For discussion, not merge

### DIFF
--- a/src/main/java/com/github/jtakakura/gradle/tasks/robovm/CreateIPATask.java
+++ b/src/main/java/com/github/jtakakura/gradle/tasks/robovm/CreateIPATask.java
@@ -34,7 +34,7 @@ public class CreateIPATask extends AbstractRoboVMTask {
     @Override
     public void invoke() {
         try {
-            Config config = build(OS.ios, Arch.thumbv7, TargetType.ios, true);
+            Config config = build(OS.ios, Arch.thumbv7, TargetType.ios, false);
             IOSTarget target = (IOSTarget) config.getTarget();
             target.createIpa();
         } catch (IOException e) {


### PR DESCRIPTION
When I tried to upload my IPA file to Apple I got a verification error `non public symbols in exc_server`. I tracked it down do the `-lrobovm-debug` flag robovm uses when compiling (clang++).

I installed a local version of the gradle plugin (with skipInstall=false) and used it for building the IPA and it passed.

The question is though, what is the valid thing to do here, should the skipInstall variable be true, and something in robovm needs to be changed? Or is this just a bug and this pull request fixes it?

I don't know enough about robovm to make that call, started using it this week, therefor this pull request and discussion.

Looking forward to your response!
## Info about the commit

The flag ´-lrobovm-debug´ makes the validation service fail when trying to upload the IPA to Apple.
Fails with message "non public symbols in exc_server"

Flag is set if skipInstall is true at:
https://github.com/robovm/robovm/blob/36b4fd955a8acbae0459550d324c5c70d996ee6c/compiler/src/main/java/org/robovm/compiler/target/AbstractTarget.java#L98
