### PR TITLE
Accept simulator local properties over project ones

### DIFF
--- a/src/main/java/org/robovm/gradle/tasks/AbstractIOSSimulatorTask.java
+++ b/src/main/java/org/robovm/gradle/tasks/AbstractIOSSimulatorTask.java
@@ -31,57 +31,56 @@ import org.robovm.compiler.target.ios.IOSTarget;
  * @author Junji Takakura
  */
 abstract public class AbstractIOSSimulatorTask extends AbstractRoboVMTask {
-    
     protected void launch(DeviceType type) {
         try {
             AppCompiler compiler = build(OS.ios, getArch(), IOSTarget.TYPE);
             Config config = compiler.getConfig();
-            
+
             IOSSimulatorLaunchParameters launchParameters = (IOSSimulatorLaunchParameters) config.getTarget().createLaunchParameters();
             launchParameters.setDeviceType(type);
-            
+
             if (extension.getStdoutFifo() != null) {
                 File stdoutFifo = new File(extension.getStdoutFifo());
                 boolean isWritable;
-                
+
                 if (stdoutFifo.exists()) {
                     isWritable = stdoutFifo.isFile() && stdoutFifo.canWrite();
                 } else {
                     File parent = stdoutFifo.getParentFile();
                     isWritable = parent != null && parent.isDirectory() && parent.canWrite();
                 }
-                
+
                 if (!isWritable) {
                     throw new GradleException("Unwritable 'stdoutFifo' specified for RoboVM compile: " + stdoutFifo);
                 }
-                
+
                 launchParameters.setStdoutFifo(stdoutFifo);
             }
-            
+
             if (extension.getStderrFifo() != null) {
                 File stderrFifo = new File(extension.getStderrFifo());
                 boolean isWritable;
-                
+
                 if (stderrFifo.exists()) {
                     isWritable = stderrFifo.isFile() && stderrFifo.canWrite();
                 } else {
                     File parent = stderrFifo.getParentFile();
                     isWritable = parent != null && parent.isDirectory() && parent.canWrite();
                 }
-                
+
                 if (!isWritable) {
                     throw new GradleException("Unwritable 'stderrFifo' specified for RoboVM compile: " + stderrFifo);
                 }
-                
+
                 launchParameters.setStderrFifo(stderrFifo);
             }
-            
+
             compiler.launch(launchParameters);
         } catch (Throwable t) {
             throw new GradleException("Failed to launch IOS Simulator", t);
         }
     }
-    
+
     protected Arch getArch() {
         Arch arch = Arch.x86_64;
         if (extension.getArch() != null && extension.getArch().equals(Arch.x86.toString())) {
@@ -89,7 +88,7 @@ abstract public class AbstractIOSSimulatorTask extends AbstractRoboVMTask {
         }
         return arch;
     }
-    
+
     protected Arch getTaskArch(String archIn) {
         Arch arch = Arch.x86_64;
         if (archIn != null && archIn.equals(Arch.x86.toString())) {
@@ -97,7 +96,7 @@ abstract public class AbstractIOSSimulatorTask extends AbstractRoboVMTask {
         }
         return arch;
     }
-    
+
     protected String getProjectOrLocal(String propertyName) {
         if (hasProperty(propertyName)) {
             return (String )property(propertyName);
@@ -105,9 +104,9 @@ abstract public class AbstractIOSSimulatorTask extends AbstractRoboVMTask {
             return (String) project.getProperties().get(propertyName);
         }
     }
-    
+
     protected DeviceType getDeviceType(DeviceType.DeviceFamily family) {
-        
+
         // Prefer the task properties over project ones, so the concrete simulator tasks can be subclasses with overriden properties
         String DEVICE_NAME = "robovm.device.name";
         String SDK_VERSION = "robovm.sdk.version";
@@ -124,5 +123,5 @@ abstract public class AbstractIOSSimulatorTask extends AbstractRoboVMTask {
         }
         return DeviceType.getBestDeviceType(arch, family, deviceName, sdkVersion);
     }
-    
+
 }


### PR DESCRIPTION
Try to solve the issue #50. 
Now I can define multiple predefined simulators in my gradle build like so:

``` groovy
task launchIPadAirSimulator(type: org.robovm.gradle.tasks.IPadSimulatorTask) {
  ext."robovm.device.name" = "iPad-Air"
  ext."robovm.arch" = "x86"
  ext."robovm.sdk.version" = "8.4"
}

task launchIPad2Simulator(type: org.robovm.gradle.tasks.IPadSimulatorTask) {
  ext."robovm.device.name" = "iPad-2"
  ext."robovm.arch" = "x86"
}

task launchIPhone5sSimulator(type: org.robovm.gradle.tasks.IPhoneSimulatorTask) {

  ext."robovm.device.name" = "iPhone-5s"
  ext."robovm.arch" = "x86_64"
}
```
