### PR TITLE
Shading robovm-gradle-plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ buildscript {
 
     dependencies {
         classpath 'org.gradle.api.plugins:gradle-nexus-plugin:0.7.1'
+        classpath "com.github.jengelman.gradle.plugins:shadow:1.2.3"
     }
 }
 
@@ -13,6 +14,7 @@ apply plugin: 'groovy'
 apply plugin: 'maven'
 apply plugin: 'nexus'
 apply plugin: 'eclipse'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 group = 'org.robovm'
 archivesBaseName = 'robovm-gradle-plugin'
@@ -33,12 +35,12 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile localGroovy()    
+    compile localGroovy()
     compile "org.apache.commons:commons-compress:1.5"
     compile "org.robovm:robovm-dist-compiler:${roboVMVersion}"
     compile 'org.sonatype.aether:aether:1.13.1'
     compile 'org.sonatype.aether:aether-connector-wagon:1.13.1'
-    compile 'org.apache.maven:maven-aether-provider:3.0.4'    
+    compile 'org.apache.maven:maven-aether-provider:3.0.4'
     compile 'org.apache.maven.wagon:wagon-provider-api:2.4'
     compile 'org.apache.maven.wagon:wagon-http:2.4'
     testCompile group: 'junit', name: 'junit', version: '4.11'
@@ -46,36 +48,36 @@ dependencies {
 
 modifyPom {
     project {
-       name 'RoboVM Gradle Plugin'
-       packaging 'jar'
-       description 'The RoboVM Gradle Plugin provides a way to build RoboVM apps using Gradle.'
-       url 'http://www.robovm.com/'
-       inceptionYear '2013'
+        name 'RoboVM Gradle Plugin'
+        packaging 'jar'
+        description 'The RoboVM Gradle Plugin provides a way to build RoboVM apps using Gradle.'
+        url 'http://www.robovm.com/'
+        inceptionYear '2013'
 
-       scm {
-           url 'https://github.com/robovm/robovm-gradle-plugin.git'
-           connection 'scm:git:git://github.com/robovm/robovm-gradle-plugin.git'
-           developerConnection 'scm:git:git@github.com:robovm/robovm-gradle-plugin.git'
-       }
+        scm {
+            url 'https://github.com/robovm/robovm-gradle-plugin.git'
+            connection 'scm:git:git://github.com/robovm/robovm-gradle-plugin.git'
+            developerConnection 'scm:git:git@github.com:robovm/robovm-gradle-plugin.git'
+        }
 
-       licenses {
-           license {
-               name 'The Apache Software License, Version 2.0'
-               url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-               distribution 'repo'
-           }
-       }
+        licenses {
+            license {
+                name 'The Apache Software License, Version 2.0'
+                url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                distribution 'repo'
+            }
+        }
 
-       developers {
-           developer {
-               id 'jtakakura'
-               name 'Junji Takakura'
-           }
-           developer {
-               id 'ntherning'
-               name 'Niklas Therning'
-           }
-       }
+        developers {
+            developer {
+                id 'jtakakura'
+                name 'Junji Takakura'
+            }
+            developer {
+                id 'ntherning'
+                name 'Niklas Therning'
+            }
+        }
     }
 }
 
@@ -84,3 +86,19 @@ task wrapper(type: Wrapper) {
 }
 
 // apply from: 'local.gradle'
+
+jar {
+    enabled = false
+}
+
+shadowJar {
+    classifier = ''
+    dependencies {
+        exclude(dependency("org.robovm:robovm-dist-compiler:${roboVMVersion}"))
+    }
+    relocate 'org.apache.http', 'org.robovm.org.apache.http'
+    relocate 'org.apache.commons.io', 'org.robovm.org.apache.commons.io'
+}
+
+assemble.dependsOn('shadowJar')
+install.dependsOn('shadowJar')


### PR DESCRIPTION
Shaded packages 'org.apache.http' and 'org.apache.commons.io' due to clashes with other Gradle plugins.
